### PR TITLE
Feature/missing hearings

### DIFF
--- a/hearing.py
+++ b/hearing.py
@@ -39,8 +39,8 @@ def get_plaintiff(soup):
 
 def get_defendants(soup):
     defendants = []
-    for tag in soup.find_all(text="Defendant"):
-        name_elem = tag.parent.find_next_sibling("th")
+    for tag in soup.find_all("th", text="Defendant"):
+        name_elem = tag.find_next_sibling("th")
         defendants.append(name_elem.text)
     together = "; ".join(defendants)
     return together

--- a/hearing.py
+++ b/hearing.py
@@ -66,28 +66,33 @@ def get_zip(soup):
 
 
 def get_hearing_tag(soup):
+    """
+    Returns the element in the Events and Hearings section of a CaseDetail document
+    that holds the most recent hearing info if one has taken place.
+    """
     def ends_with_hearing(string: str) -> bool:
         return string.endswith("Hearing")
+    hearings = soup.find_all("b", string=ends_with_hearing)
+    return hearings[-1] if len(hearings) > 0 else None
 
-    return soup.find_all("b", string=ends_with_hearing)[-1]
 
-
-def get_hearing_text(soup):
+def get_hearing_text(soup) -> str:
     hearing_tag = get_hearing_tag(soup)
-    return hearing_tag.next_sibling
+    return hearing_tag.next_sibling if hearing_tag is not None else ""
 
 
 def get_hearing_date(soup) -> str:
     hearing_tag = get_hearing_tag(soup)
+    if hearing_tag is None:
+        return ""
     date_tag = hearing_tag.parent.find_previous_sibling("th")
     return date_tag.text
 
 
 def get_hearing_time(soup) -> str:
     hearing_text = get_hearing_text(soup)
-    up_to_time = hearing_text.split(")")[0]
-    just_time = up_to_time.split("(")[1]
-    return just_time
+    hearing_time_matches = re.search(r"\d{1,2}:\d{2} [AP]M", hearing_text)
+    return hearing_time_matches[0] if hearing_time_matches is not None else ""
 
 
 def get_hearing_officer(soup) -> str:

--- a/hearing.py
+++ b/hearing.py
@@ -97,7 +97,8 @@ def get_hearing_time(soup) -> str:
 
 def get_hearing_officer(soup) -> str:
     hearing_text = get_hearing_text(soup)
-    name = hearing_text.split("Judicial Officer")[1]
+    officer_groups = hearing_text.split("Judicial Officer")
+    name = officer_groups[1] if len(officer_groups) > 1 else ""
     return name.strip().strip(")")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,14 @@
-BeautifulSoup4
-click
-selenium
+attrs==19.3.0
+beautifulsoup4==4.9.1
+click==7.1.2
+more-itertools==8.3.0
+packaging==20.4
+pluggy==0.13.1
+py==1.8.1
+pyparsing==2.4.7
+pytest==5.4.2
+selenium==3.141.0
+six==1.15.0
+soupsieve==2.0.1
+urllib3==1.25.9
+wcwidth==0.1.9


### PR DESCRIPTION
Some persnickety errors prevent completing long runs when a CaseDetail page with no hearings recorded was encountered.